### PR TITLE
Publish show notes to a GitHub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,20 @@ First you need to create a [Slack app](https://api.slack.com/start) and install 
 6. save the _Bot User OAuth Token_ for later in _Features > OAuth & Permissions_ (it will be referred
    as `SLACK_BOT_TOKEN`).
 
-You can then start the bot using the following commands (from the project directory) :
+Then you need to create a GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+and a _publication_ repository (a repository where the show notes will be published) :
+
+1. go to [https://github.com/settings/tokens/new](https://github.com/settings/tokens/new),
+2. create a new personal access token with the scope `repo` and save it for later (it will be referred as `GITHUB_TOKEN`),
+3. create, if needed, a new _publication_ repository and keep its coordinates (it will be referred as `GITHUB_REPOSITORY`).
+
+Finally, you can start the bot using the following commands (from the project root directory) :
 
 ```shell
 quarkus build
 
+export GITHUB_TOKEN='ghp_XXX'
+export GITHUB_REPOSITORY='lescastcodeurs/staging-lescastcodeurs.com'
 export SLACK_APP_TOKEN='xapp-XXX'
 export SLACK_BOT_TOKEN='xoxb-XXX'
 java -jar build/quarkus-app/quarkus-run.jar

--- a/src/main/java/com/lescastcodeurs/bot/Constants.java
+++ b/src/main/java/com/lescastcodeurs/bot/Constants.java
@@ -17,6 +17,20 @@ public final class Constants {
   public static final String SLACK_BOT_TOKEN = "slack.bot.token";
 
   /**
+   * Configuration key for GitHub token ({@code xoxb-XXX}).
+   * <p>
+   * For more information see the project README.
+   */
+  public static final String GITHUB_TOKEN = "github.token";
+
+  /**
+   * Configuration key for GitHub repository ({@code owner/repo}).
+   * <p>
+   * For more information see the project README.
+   */
+  public static final String GITHUB_REPOSITORY = "github.repository";
+
+  /**
    * Address for the {@link com.lescastcodeurs.bot.GenerateShowNotesHandler}.
    */
   public static final String GENERATE_SHOW_NOTES_ADDRESS =

--- a/src/main/java/com/lescastcodeurs/bot/GitHubApiException.java
+++ b/src/main/java/com/lescastcodeurs/bot/GitHubApiException.java
@@ -1,0 +1,24 @@
+package com.lescastcodeurs.bot;
+
+import java.net.URI;
+import java.net.http.HttpResponse;
+
+public class GitHubApiException extends RuntimeException {
+
+  private final int status;
+  private final URI uri;
+
+  public GitHubApiException(HttpResponse<String> response) {
+    super(response.body());
+    this.status = response.statusCode();
+    this.uri = response.uri();
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public URI getUri() {
+    return uri;
+  }
+}

--- a/src/main/java/com/lescastcodeurs/bot/GitHubClient.java
+++ b/src/main/java/com/lescastcodeurs/bot/GitHubClient.java
@@ -1,0 +1,114 @@
+package com.lescastcodeurs.bot;
+
+import static com.lescastcodeurs.bot.Constants.GITHUB_REPOSITORY;
+import static com.lescastcodeurs.bot.Constants.GITHUB_TOKEN;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Base64;
+import javax.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class GitHubClient {
+
+  private static final String GITHUB_URL = "https://github.com";
+  private static final String GITHUB_API_URL = "https://api.github.com";
+
+  private final String token;
+  private final String repository;
+
+  private final Base64.Encoder encoder;
+  private final HttpClient client;
+
+  public GitHubClient(
+    @ConfigProperty(name = GITHUB_TOKEN) String token,
+    @ConfigProperty(name = GITHUB_REPOSITORY) String repository
+  ) {
+    this.token = token;
+    this.repository = repository;
+    this.client =
+      HttpClient
+        .newBuilder()
+        .version(HttpClient.Version.HTTP_2)
+        .connectTimeout(Duration.ofSeconds(10))
+        .build();
+    this.encoder = Base64.getEncoder();
+  }
+
+  /**
+   * Create a new file in the configured {@link #repository} under the given filename.
+   *
+   * @see <a href="https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents">Create or update file contents</a>
+   */
+  public String createFile(String filename, String content)
+    throws InterruptedException {
+    send(
+      HttpRequest
+        .newBuilder(URI.create(gitHubApiUrl(filename)))
+        .header("Accept", "application/vnd.github.v3+json")
+        .header("Authorization", "token " + token)
+        .PUT(
+          HttpRequest.BodyPublishers.ofString(
+            """
+            {
+              "message": "publish show notes",
+              "committer": { "name": "@lcc", "email": "commentaire@lescastcodeurs.com" },
+              "content": "%s"
+            }
+            """.formatted(
+                base64(content)
+              )
+          )
+        )
+        .build(),
+      201
+    );
+
+    return gitHubUrl(filename);
+  }
+
+  private String gitHubApiUrl(String filename) {
+    return "%s/repos/%s/contents/%s".formatted(
+        GITHUB_API_URL,
+        repository,
+        filename
+      );
+  }
+
+  private String gitHubUrl(String filename) {
+    return "%s/%s/blob/main/%s".formatted(GITHUB_URL, repository, filename);
+  }
+
+  private String base64(String content) {
+    return encoder.encodeToString(content.getBytes(UTF_8));
+  }
+
+  private HttpResponse<String> send(
+    HttpRequest request,
+    int expectedResponseCode
+  ) throws InterruptedException {
+    try {
+      HttpResponse<String> response = client.send(
+        request,
+        BodyHandlers.ofString()
+      );
+
+      int status = response.statusCode();
+      if (status == expectedResponseCode) {
+        return response;
+      } else {
+        throw new GitHubApiException(response);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/src/main/slack/manifest.yml
+++ b/src/main/slack/manifest.yml
@@ -9,7 +9,7 @@ display_information:
 
     1- it reads all the messages in the current Slack channel,
     2- it generates the show notes in markdown format,
-    3- it publishes the markdown file to the GitHub wiki of lescastcodeurs.com.
+    3- it publishes the markdown file to lescastcodeurs.com staging GitHub repository.
   background_color: '#997704'
 
 features:

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,4 @@
+github.token=ghp_XXX
+github.repository=owner/repo
 slack.app.token=xapp-XXX
 slack.bot.token=xoxb-XXX


### PR DESCRIPTION
Unfortunately it is not possible to publish notes to a GitHub wiki through the GitHub API although wikis are git repositories (https://stackoverflow.com/questions/2402413/update-a-github-project-wiki-through-the-github-api). For the record, I tried to suffixing the repo name in the API URL with '.wiki' and '.wiki.git' but it did not work.