### PR TITLE
Keep slack formatting in show notes

### DIFF
--- a/src/main/java/com/lescastcodeurs/bot/SlackMessage.java
+++ b/src/main/java/com/lescastcodeurs/bot/SlackMessage.java
@@ -2,11 +2,40 @@ package com.lescastcodeurs.bot;
 
 import com.slack.api.model.Message;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
- * Extract required information from a Slack message.
+ * Hold required information from a Slack message.
  */
 public final class SlackMessage {
+
+  /**
+   * @see <a href="https://stackoverflow.com/a/1547940">Which characters make a URL invalid?</a>
+   * @see <a href="https://stackoverflow.com/a/417184/374236">What is the maximum length of a URL in different browsers?</a>
+   */
+  private static final String URL_CHARACTER_REGEX =
+    "[A-Za-z\\d-._~:/?#\\[\\]@!$&'()*+,;=%]";
+  private static final Pattern SLACK_RAW_URL_PATTERN = Pattern.compile(
+    "<(?<url>http" + URL_CHARACTER_REGEX + "{10,2000})>"
+  );
+  private static final Pattern SLACK_TITLED_URL_PATTERN = Pattern.compile(
+    "<(?<url>http" +
+    URL_CHARACTER_REGEX +
+    "{10,2000})\\|(?<title>[^>]{1,20000})>"
+  );
+
+  private static final Pattern BOLD_PATTERN = Pattern.compile(
+    "\\*(?<content>[^*]+)\\*"
+  );
+
+  private static final Pattern LIST_PATTERN = Pattern.compile(
+    "^\\s*•\\s+",
+    Pattern.MULTILINE
+  );
+  private static final Pattern SUBLIST_PATTERN = Pattern.compile(
+    "^ \\s*◦\\s+",
+    Pattern.MULTILINE
+  );
 
   public static final String DEFAULT_TS = "9999999999.999999";
 
@@ -33,7 +62,37 @@ public final class SlackMessage {
     return text;
   }
 
+  /**
+   * Convert this message {@link #text()} as markdown.
+   *
+   * @see <a href="https://api.slack.com/reference/surfaces/formatting">Formatting text for app surfaces</a>
+   * @see <a href="https://www.markdownguide.org/tools/slack/">Slack Markdown Reference | Markdown Guide</a>
+   */
+  public String asMarkdown() {
+    return convertToMarkdown(text);
+  }
+
   public List<String> replies() {
     return replies;
+  }
+
+  public List<String> repliesAsMarkdown() {
+    return replies.stream().map(this::convertToMarkdown).toList();
+  }
+
+  private String convertToMarkdown(String text) {
+    String markdown = text;
+
+    markdown =
+      SLACK_RAW_URL_PATTERN.matcher(markdown).replaceAll("[${url}](${url})");
+    markdown =
+      SLACK_TITLED_URL_PATTERN
+        .matcher(markdown)
+        .replaceAll("[${title}](${url})");
+    markdown = BOLD_PATTERN.matcher(markdown).replaceAll("**${content}**");
+    markdown = LIST_PATTERN.matcher(markdown).replaceAll("- ");
+    markdown = SUBLIST_PATTERN.matcher(markdown).replaceAll("  - ");
+
+    return markdown;
   }
 }

--- a/src/main/resources/templates/show-notes.md
+++ b/src/main/resources/templates/show-notes.md
@@ -20,154 +20,154 @@ Téléchargement de l’épisode [LesCastCodeurs-Episode-999.mp3](https://traffi
 ### Non catégorisées
 
 {#for note in notes('news')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Langages
 
 {#for note in notes('Langages')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Librairies
 
 {#for note in notes('Librairies')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Infrastructure
 
 {#for note in notes('Infrastructure')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Cloud
 
 {#for note in notes('Cloud')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Web
 
 {#for note in notes('Web')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Data
 
 {#for note in notes('Data')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Outillage
 
 {#for note in notes('Outillage')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Architecture
 
 {#for note in notes('Architecture')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Méthodologies
 
 {#for note in notes('Méthodologies')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Sécurité
 
 {#for note in notes('Sécurité')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ### Loi, société et organisation
 
 {#for note in notes('Loi')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ## Outils de l’épisode
 
 {#for note in notes('Outils')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
 ## Rubrique débutant
 
 {#for note in notes('débutant')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 
@@ -177,11 +177,11 @@ Téléchargement de l’épisode [LesCastCodeurs-Episode-999.mp3](https://traffi
 TODO: reprendre celles de l’épisode d’avant
 
 {#for note in notes('Conférences')}
-{note.url}
+{note.text}
 
 {#for comment in note.comments}
-- {comment}
-  {/for}
+{comment}
+{/for}
 
 {/for}
 

--- a/src/test/java/com/lescastcodeurs/bot/ShowNoteTest.java
+++ b/src/test/java/com/lescastcodeurs/bot/ShowNoteTest.java
@@ -27,21 +27,11 @@ class ShowNoteTest {
   }
 
   @Test
-  void sameMessageData() {
-    var message = new SlackMessage(TS, NOTE_URL, List.of("a", "b", "c"));
-    var note = new ShowNote(message);
-
-    assertEquals(message.timestamp(), note.timestamp());
-    assertEquals(message.text(), note.text());
-    assertEquals(message.replies(), note.replies());
-  }
-
-  @Test
   void url() {
     var message = new SlackMessage(TS, NOTE_URL, List.of());
     var note = new ShowNote(message);
 
-    assertEquals(URL, note.url());
+    assertTrue(note.text().contains(URL));
   }
 
   @Test
@@ -61,6 +51,9 @@ class ShowNoteTest {
     );
     var note = new ShowNote(message);
 
-    assertEquals(List.of("note 1", "note 2", "note 3"), note.comments());
+    assertEquals(
+      List.of("- note 1", "- note 2\t", "- note 3 "),
+      note.comments()
+    );
   }
 }

--- a/src/test/java/com/lescastcodeurs/bot/SlackMessageTest.java
+++ b/src/test/java/com/lescastcodeurs/bot/SlackMessageTest.java
@@ -1,6 +1,7 @@
 package com.lescastcodeurs.bot;
 
 import static com.lescastcodeurs.bot.SlackMessage.DEFAULT_TS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
@@ -27,5 +28,120 @@ class SlackMessageTest {
     SlackMessage slackMessage = new SlackMessage(DEFAULT_TS, "msg", null);
 
     assertNotNull(slackMessage.replies());
+  }
+
+  @Test
+  void rawLinksAreProperlyTransformedToMarkdownLinks() {
+    SlackMessage message = new SlackMessage(
+      DEFAULT_TS,
+      "<https://lescastcodeurs.com/>",
+      null
+    );
+
+    assertEquals(
+      "[https://lescastcodeurs.com/](https://lescastcodeurs.com/)",
+      message.asMarkdown()
+    );
+  }
+
+  @Test
+  void titledLinksAreProperlyTransformedToMarkdownLinks() {
+    SlackMessage message = new SlackMessage(
+      DEFAULT_TS,
+      "<https://lescastcodeurs.com/|Le podcast Java en Français>",
+      null
+    );
+
+    assertEquals(
+      "[Le podcast Java en Français](https://lescastcodeurs.com/)",
+      message.asMarkdown()
+    );
+  }
+
+  @Test
+  void boldIsProperlyTransformed() {
+    SlackMessage message = new SlackMessage(
+      DEFAULT_TS,
+      "*some bold text*",
+      null
+    );
+
+    assertEquals("**some bold text**", message.asMarkdown());
+  }
+
+  @Test
+  void listIsProperlyTransformed() {
+    SlackMessage message = new SlackMessage(
+      DEFAULT_TS,
+      """
+    • element 1
+    • element 2
+    """,
+      null
+    );
+
+    assertEquals(
+      """
+    - element 1
+    - element 2
+    """,
+      message.asMarkdown()
+    );
+  }
+
+  @Test
+  void sublistIsProperlyTransformed() {
+    SlackMessage message = new SlackMessage(
+      DEFAULT_TS,
+      """
+    • element 1
+      ◦ subelement 1
+      ◦ subelement 2
+    """,
+      null
+    );
+
+    assertEquals(
+      """
+    - element 1
+      - subelement 1
+      - subelement 2
+    """,
+      message.asMarkdown()
+    );
+  }
+
+  @Test
+  void complexMessageIsProperlyTransformedToMarkdown() {
+    SlackMessage message = new SlackMessage(
+      DEFAULT_TS,
+      """
+      • <https://lescastcodeurs.com/|Le podcast Java en Français>
+        ◦ something to say on this link ?
+      • <https://lescastcodeurs.com/>
+      • <http://example.com/blue+light%20blue?blue%2Blight+blu|I think I blue myself!>
+      • Formatting:
+       ◦ *some bold text*
+       ◦ _some italic text_
+       ◦ ~some striked text~
+       ◦ `some code`
+      """,
+      null
+    );
+
+    assertEquals(
+      """
+      - [Le podcast Java en Français](https://lescastcodeurs.com/)
+        - something to say on this link ?
+      - [https://lescastcodeurs.com/](https://lescastcodeurs.com/)
+      - [I think I blue myself!](http://example.com/blue+light%20blue?blue%2Blight+blu)
+      - Formatting:
+        - **some bold text**
+        - _some italic text_
+        - ~some striked text~
+        - `some code`
+      """,
+      message.asMarkdown()
+    );
   }
 }

--- a/src/test/java/com/lescastcodeurs/bot/TestConstants.java
+++ b/src/test/java/com/lescastcodeurs/bot/TestConstants.java
@@ -7,7 +7,7 @@ public interface TestConstants {
   String URL = "https://google.com";
   String HTTP_URL = "http://google.com";
 
-  String NOTE_URL = "<%s> (%s)".formatted(URL, CATEGORY);
-  String NOTE_HTTP_URL = "<%s> (%s)".formatted(HTTP_URL, CATEGORY);
+  String NOTE_URL = "%s: <%s>".formatted(CATEGORY, URL);
+  String NOTE_HTTP_URL = "%s: <%s>".formatted(CATEGORY, HTTP_URL);
   String UNCATEGORIZED_NOTE_URL = "<%s>".formatted(URL);
 }


### PR DESCRIPTION
Formatting in slack messages is now transformed to markdown. This allows us to properly display in show notes : links, bold text, sublists.
Italic, strikethrough and code are the same in slack messages and markdown, so it did not require any transformations.