### PR TITLE
Ajout de la commande SHOW_CATEGORIES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Ajout d'une nouvelle commande pour afficher la liste triée des catégories et de leurs libellés de manières plus
+  condensée qu'auparavant (#39).
+
 ### Changed
 
 ### Fixed
@@ -15,8 +18,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Dependencies
 
-- Upgrade spotless from 6.8.0 to [6.10.0](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#6100---2022-08-23)
-  (#34).
+- Upgrade spotless from 6.8.0 to
+  [6.10.0](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#6100---2022-08-23) (#34).
 - Upgrade quarkus from 2.10.2 to [2.11.2](https://quarkus.io/blog/quarkus-2-11-2-final-released/) (#35, #47).
 - Upgrade java version to [temurin-17.0.4+8](https://www.oracle.com/java/technologies/javase/17-0-4-relnotes.html)
   (#36).

--- a/src/main/java/com/lescastcodeurs/bot/ShowNoteCategory.java
+++ b/src/main/java/com/lescastcodeurs/bot/ShowNoteCategory.java
@@ -30,7 +30,7 @@ public enum ShowNoteCategory {
       "organization",
       "orga",
       "org"),
-  EPISODE_TOOL("Outils de l’épisode", "outils", "outil", "tools", "tool"),
+  TOOL_OF_THE_EPISODE("Outils de l’épisode", "outils", "outil", "tools", "tool"),
   BEGINNERS("Rubrique débutant", "debutants", "debutant", "beginners", "beginner"),
   CONFERENCE("Conférences", "conferences", "conference", "conf");
 

--- a/src/main/java/com/lescastcodeurs/bot/SlackBotAction.java
+++ b/src/main/java/com/lescastcodeurs/bot/SlackBotAction.java
@@ -1,10 +1,11 @@
 package com.lescastcodeurs.bot;
 
 import static java.util.Arrays.stream;
-import static java.util.Comparator.comparingInt;
+import static java.util.Comparator.*;
 import static java.util.stream.Collectors.joining;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -17,7 +18,7 @@ public enum SlackBotAction {
       "permet de vérifier que je suis à l'écoute."),
 
   HELP(
-      2,
+      10,
       List.of("aide", "help"),
       null,
       List.of("@lcc, à l'aide !", "@lcc, help me please !"),
@@ -38,6 +39,28 @@ public enum SlackBotAction {
     }
   },
 
+  SHOW_CATEGORIES(
+      20,
+      List.of("category", "categorie", "label", "libelle", "tag"),
+      """
+      Les catégories, et leurs libellés associés, sont : %s
+      """
+          .formatted(
+              stream(ShowNoteCategory.values())
+                  .sorted(comparing(ShowNoteCategory::name))
+                  .map(
+                      c ->
+                          "%s (%s)"
+                              .formatted(
+                                  c.description().toLowerCase(Locale.FRENCH),
+                                  c.getLabels().stream()
+                                      .sorted(naturalOrder())
+                                      .map("`%s`"::formatted)
+                                      .collect(joining(", "))))
+                  .collect(joining(", "))),
+      List.of("@lcc, montre-moi les catégories.", "@lcc, show me the categories."),
+      "affiche la liste des catégories avec leurs libellés associés."),
+
   GENERATE_SHOW_NOTES(
       3,
       List.of("genere", "generate"),
@@ -49,20 +72,8 @@ public enum SlackBotAction {
       • Un thread de messages est reporté dans les show notes si son premier message contient au moins un lien.
       • Les réponses aux liens peuvent être de simples phrases comme des listes.
       • La formatage suivant est conservé : *gras*, _italique_, ~barré~, `code`.
-      • Les liens peuvent être catégorisés à l'aide de libellés (ex. `https://www.google.com (outillage)`). Les catégories, avec les libellés qu'il est possible d'utiliser, sont :
-          ◦ %s
-      """
-          .formatted(
-              stream(ShowNoteCategory.values())
-                  .map(
-                      c ->
-                          "%s (%s)"
-                              .formatted(
-                                  c.description(),
-                                  c.getLabels().stream()
-                                      .map("`%s`"::formatted)
-                                      .collect(joining(", "))))
-                  .collect(joining("\n    ◦ "))),
+      • Les liens peuvent être catégorisés à l'aide de libellés (ex. `https://www.google.com (outillage)`). Les catégories, avec les libellés qu'il est possible d'utiliser, sont visibles grâce à la commande dédiée (`@lcc, affiche les catégories.`).
+      """,
       Constants.GENERATE_SHOW_NOTES_ADDRESS),
 
   UNKNOWN(999, List.of(), null, List.of(), null) {


### PR DESCRIPTION
Cette commande permet de n'afficher que la liste triée des catégories et de leurs libellés de manières plus condensée qu'auparavant.