### PR TITLE
 Afficher l'ensemble des mots clés des commandes (closes #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Tous les mots clés associés aux commandes sont désormais affichés (#48).
+
 ### Fixed
 
 ### Deprecated

--- a/src/main/java/com/lescastcodeurs/bot/SlackBotAction.java
+++ b/src/main/java/com/lescastcodeurs/bot/SlackBotAction.java
@@ -26,7 +26,7 @@ public enum SlackBotAction {
     @Override
     public String response() {
       return """
-        Voici les commandes auxquelles je peux répondre (la ponctuation, les accents, la casse ainsi que la présence de mots supplémentaires sont ignorés).
+        Voici les commandes auxquelles je peux répondre (la ponctuation, les accents, la casse ainsi que la présence de mots ou caractères supplémentaires sont ignorés).
 
         %s
         """
@@ -176,7 +176,7 @@ public enum SlackBotAction {
   }
 
   public String help() {
-    String commands = keywords.stream().limit(2).map("*%s*"::formatted).collect(joining(" | "));
+    String commands = keywords.stream().map("*%s*"::formatted).collect(joining(" | "));
     String examples = usages.stream().map("`%s`"::formatted).collect(joining(", "));
     return "%s (%s) : %s".formatted(commands, examples, description);
   }


### PR DESCRIPTION
Le nombre de mots clé maximum affichés pour chaque commande était de deux. L'inconvénient est que le bot pouvait réagir à certaines commandes sans que l'utilisateur puisse savoir pourquoi.