### PR TITLE
Gestion des citations (closes #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Ajout d'une nouvelle commande pour afficher la liste triée des catégories et de leurs libellés de manières plus
   condensée qu'auparavant (#39).
+- Gestion des citations (#38). Les chevrons, qui sont HTML-encodés dans les messages Slack, sont désormais désencodés
+  afin d'être correctement interprétés dans le markdown. Et les retours chariots sont désormais conservés sur le premier
+  message.
 
 ### Changed
 

--- a/src/main/java/com/lescastcodeurs/bot/ShowNote.java
+++ b/src/main/java/com/lescastcodeurs/bot/ShowNote.java
@@ -51,7 +51,7 @@ public class ShowNote {
   }
 
   public String text() {
-    String markdown = message.asMarkdown().replace("\n", " ");
+    String markdown = message.asMarkdown();
     Optional<ShowNoteCategory> category = ShowNoteCategory.find(urlMatcher.group("category"));
 
     if (category.isPresent()) {

--- a/src/main/java/com/lescastcodeurs/bot/SlackBotAction.java
+++ b/src/main/java/com/lescastcodeurs/bot/SlackBotAction.java
@@ -71,7 +71,7 @@ public enum SlackBotAction {
       • Un channel Slack doit être dédié à un seul épisode.
       • Un thread de messages est reporté dans les show notes si son premier message contient au moins un lien.
       • Les réponses aux liens peuvent être de simples phrases comme des listes.
-      • La formatage suivant est conservé : *gras*, _italique_, ~barré~, `code`.
+      • La formatage suivant est conservé : *gras*, _italique_, ~barré~, `code` et citations (sur le premier message uniquement).
       • Les liens peuvent être catégorisés à l'aide de libellés (ex. `https://www.google.com (outillage)`). Les catégories, avec les libellés qu'il est possible d'utiliser, sont visibles grâce à la commande dédiée (`@lcc, affiche les catégories.`).
       """,
       Constants.GENERATE_SHOW_NOTES_ADDRESS),

--- a/src/main/java/com/lescastcodeurs/bot/SlackMessage.java
+++ b/src/main/java/com/lescastcodeurs/bot/SlackMessage.java
@@ -94,6 +94,8 @@ public final class SlackMessage {
     markdown = BOLD_PATTERN.matcher(markdown).replaceAll("**${content}**");
     markdown = LIST_PATTERN.matcher(markdown).replaceAll("- ");
     markdown = SUBLIST_PATTERN.matcher(markdown).replaceAll("  - ");
+    markdown = markdown.replace("&gt;", ">");
+    markdown = markdown.replace("&lt;", "<");
 
     return markdown;
   }

--- a/src/test/java/com/lescastcodeurs/bot/ShowNoteTest.java
+++ b/src/test/java/com/lescastcodeurs/bot/ShowNoteTest.java
@@ -81,11 +81,11 @@ class ShowNoteTest {
             LIBRARIES),
         Arguments.of(
             "<https://test.io/>\nthis\nis\na\ntest",
-            "[https://test.io/](https://test.io/) this is a test",
+            "[https://test.io/](https://test.io/)\nthis\nis\na\ntest",
             NEWS),
         Arguments.of(
-            "bla bla\n<https://test.io/d/a.txt?a=b&c=d#!#e=f%20g|this is a test> (cloud)\nbla bla <https://link.to|link> (test)",
-            "bla bla [this is a test](https://test.io/d/a.txt?a=b&c=d#!#e=f%20g) bla bla [link](https://link.to) (test)",
+            "bla bla \n<https://test.io/d/a.txt?a=b&c=d#!#e=f%20g|this is a test> (cloud) \nbla bla <https://link.to|link> (test)",
+            "bla bla \n[this is a test](https://test.io/d/a.txt?a=b&c=d#!#e=f%20g) \nbla bla [link](https://link.to) (test)",
             CLOUD));
   }
 

--- a/src/test/java/com/lescastcodeurs/bot/SlackMessageTest.java
+++ b/src/test/java/com/lescastcodeurs/bot/SlackMessageTest.java
@@ -94,6 +94,30 @@ class SlackMessageTest {
   }
 
   @Test
+  void blockquoteIsProperlyTransformed() {
+    SlackMessage message =
+        new SlackMessage(
+            DEFAULT_TS,
+            """
+      La classe américaine, L’indien à Hugues. :
+      &gt; J’aimerais bien que tu restes.
+      &gt; On va manger des chips. Tu entends ? Des chips !
+      &gt; C’est tout ce que ça te fait quand je te dis qu’on va manger des chips ?
+      """,
+            null,
+            false);
+
+    assertEquals(
+        """
+      La classe américaine, L’indien à Hugues. :
+      > J’aimerais bien que tu restes.
+      > On va manger des chips. Tu entends ? Des chips !
+      > C’est tout ce que ça te fait quand je te dis qu’on va manger des chips ?
+      """,
+        message.asMarkdown());
+  }
+
+  @Test
   void complexMessageIsProperlyTransformedToMarkdown() {
     SlackMessage message =
         new SlackMessage(


### PR DESCRIPTION
Les retours chariot sont désormais conservé dans le premier message d'un thread. Ça n'est nécessaire que dans les réponses, puisqu'on veut les présenter sous forme de liste.

Les chevrons, qui sont HTML-encodés dans le message Slack, sont désormais désencodés afin d'être correctement interprétés dans le markdown produit.