### PR TITLE
Add the ignore category (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Support a main label for categories (#39).
 - Support blockquotes (#38).
   - Brackets (`&lt;` and `&gt;`) are now unescaped in the messages in order to be properly interpreted in the final
-    markdown document.
+    Markdown document.
   - New lines are now retained if they appear in the first message of a thread. New lines in replies are still deleted:
-    this is required because replies must be displayed in a markdown list.
+    this is required because replies must be displayed in a Markdown list.
+- Add a new category, `ignore` (#42). This category allows you to ignore a link when generating show notes.
 
 ### Changed
 

--- a/src/main/java/com/lescastcodeurs/bot/ShowNoteCategory.java
+++ b/src/main/java/com/lescastcodeurs/bot/ShowNoteCategory.java
@@ -38,6 +38,9 @@ public enum ShowNoteCategory {
   TOOL_OF_THE_EPISODE("Outils de l’épisode", "outil-ep", "outil-episode"),
   BEGINNERS("Rubrique débutant", "debutant", "debutants", "beginner", "beginners"),
   CONFERENCES("Conférences", "conf", "conferences", "conference"),
+  // This category must not be used in template.
+  IGNORED("Ignoré", "ignore", "ignorer", "ignored", "exclu", "exclude", "exclure"),
+  // Fall-back for unrecognized categories.
   NEWS("Non catégorisé", "news", "nouvelles", "nouvelle");
 
   private final String description;

--- a/src/main/java/com/lescastcodeurs/bot/SlackBotAction.java
+++ b/src/main/java/com/lescastcodeurs/bot/SlackBotAction.java
@@ -1,5 +1,7 @@
 package com.lescastcodeurs.bot;
 
+import static com.lescastcodeurs.bot.ShowNoteCategory.IGNORED;
+import static com.lescastcodeurs.bot.ShowNoteCategory.NEWS;
 import static java.util.Arrays.stream;
 import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.joining;
@@ -44,11 +46,12 @@ public enum SlackBotAction {
       """
       Les catégories et leurs libellés sont :
       • %s
+      • Ignoré: les liens catégorisés avec `%s` n'apparaissent pas dans les notes de l'épisode (%s).
       • Non catégorisé: laissé sans catégorie ou catégorisé avec un libellé inconnu
       """
           .formatted(
               stream(ShowNoteCategory.values())
-                  .filter(c -> c != ShowNoteCategory.NEWS)
+                  .filter(c -> c != NEWS && c != IGNORED)
                   .map(
                       c ->
                           "%s : `%s` (%s)"
@@ -58,7 +61,9 @@ public enum SlackBotAction {
                                   c.alternateLabels().stream()
                                       .map("`%s`"::formatted)
                                       .collect(joining(", "))))
-                  .collect(joining("\n• "))),
+                  .collect(joining("\n• ")),
+              IGNORED.mainLabel(),
+              IGNORED.alternateLabels().stream().map("`%s`"::formatted).collect(joining(", "))),
       List.of("@lcc, montre-moi les catégories.", "@lcc, show me the categories."),
       "Affiche la liste des catégories avec leurs libellés associés (multilignes, ordre de déclaration)."),
 

--- a/src/test/java/com/lescastcodeurs/bot/ShowNotesTest.java
+++ b/src/test/java/com/lescastcodeurs/bot/ShowNotesTest.java
@@ -57,7 +57,7 @@ class ShowNotesTest {
     assertTrue(rendered.startsWith("---"));
     for (ShowNoteCategory category : ShowNoteCategory.values()) {
       String url = "https://lescastcodeurs.com/" + category;
-      assertTrue(rendered.contains(url));
+      assertEquals(category != ShowNoteCategory.IGNORED, rendered.contains(url));
     }
     assertTrue(rendered.contains("- comment 1"));
     assertTrue(rendered.contains("- comment 2"));


### PR DESCRIPTION
This category allows you to ignore a link when generating show notes. It is needed when a user want to post a messages unrelated to the show notes.