### PR TITLE
Bump quarkus from 2.12.0 to 2.13.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 java temurin-17.0.4+8
-quarkus 2.12.0.Final
+quarkus 2.13.1.Final
 gradle 7.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Bump tyrus-standalone-client from 1.19 to 1.20 (#77).
 - Bump bolt-socket-mode from 1.25.1 to 1.26.1 (#79).
 - Bump com.diffplug.spotless from 6.10.0 to 6.11.0 (#76).
+- Bump quarkus from 2.12.0 to 2.13.1 (#80).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.12.0.Final
+quarkusPluginVersion=2.13.1.Final
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.12.0.Final
+quarkusPlatformVersion=2.13.1.Final
 
 # Quarkus properties
 quarkus.package.type=uber-jar


### PR DESCRIPTION
Changelog: https://github.com/quarkusio/quarkus/releases/tag/2.13.1.Final