### PR TITLE
Support ordered lists and sublists transformation (closes #98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Improve help when an error occurs, such as a timeout (#97).
+- Support ordered lists and sublists transformation from Slack syntax to GitHub flavored markdown
+  (#98). Sublists size is limited to at most 26 elements.
 
 ### Fixed
 

--- a/src/main/java/com/lescastcodeurs/bot/ShowNoteReply.java
+++ b/src/main/java/com/lescastcodeurs/bot/ShowNoteReply.java
@@ -13,7 +13,9 @@ public final class ShowNoteReply {
 
   public static final int DEFAULT_ORDER = 999;
 
-  private static final Pattern LIST_ITEM_PATTERN = Pattern.compile("^ *-");
+  private static final Pattern UNORDERED_LIST_ITEM_PATTERN = Pattern.compile("^ *-");
+  private static final Pattern ORDERED_LIST_ITEM_PATTERN = Pattern.compile("^ *\\d+\\. ");
+  private static final Pattern ORDERED_SUBLIST_ITEM_PATTERN = Pattern.compile("^ *[a-z]\\. ");
 
   private final SlackReply reply;
 
@@ -58,10 +60,15 @@ public final class ShowNoteReply {
         .filter(not(String::isBlank))
         .map(
             line -> {
-              if (LIST_ITEM_PATTERN.matcher(line).find()) {
+              if (UNORDERED_LIST_ITEM_PATTERN.matcher(line).find()
+                  || ORDERED_LIST_ITEM_PATTERN.matcher(line).find()) {
                 // Lists that do not belong to plain lists messages have to be shifted. See
                 // corresponding tests.
                 return isPlainList ? line : "  " + line;
+              } else if (ORDERED_SUBLIST_ITEM_PATTERN.matcher(line).find()) {
+                // Lists that do not belong to plain lists messages have to be shifted. See
+                // corresponding tests.
+                return (isPlainList ? line : "  " + line).replaceFirst("[a-z]\\.", "1.");
               } else {
                 return "- " + line;
               }

--- a/src/test/java/com/lescastcodeurs/bot/ShowNoteReplyTest.java
+++ b/src/test/java/com/lescastcodeurs/bot/ShowNoteReplyTest.java
@@ -3,7 +3,10 @@ package com.lescastcodeurs.bot;
 import static com.lescastcodeurs.bot.ShowNoteCategory.EXCLUDE;
 import static com.lescastcodeurs.bot.ShowNoteCategory.INCLUDE;
 import static com.lescastcodeurs.bot.ShowNoteReply.DEFAULT_ORDER;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.lescastcodeurs.bot.slack.Messages;
 import com.lescastcodeurs.bot.slack.SlackReply;
@@ -98,16 +101,51 @@ class ShowNoteReplyTest {
   }
 
   @Test
-  void nonPlainListAreConvertedToSublist() {
+  void plainListWithUnorderedSublistIsConvertedAsIs() {
     SlackReply message =
         new SlackReply(
             Messages.of(
                 """
+      - test 1
+        - subtest 1
+        - subtest 2
+      - test 2
+            """));
+    var reply = new ShowNoteReply(message);
+
+    assertEquals(
+        List.of("- test 1", "  - subtest 1", "  - subtest 2", "- test 2"),
+        reply.comments().toList());
+  }
+
+  @Test
+  void plainListWithOrderedSublistIsConvertedAsIs() {
+    SlackReply message =
+        new SlackReply(
+            Messages.of(
+                """
+      - test 1
+        a. subtest 1
+        b. subtest 2
+      - test 2
+      """));
+    var reply = new ShowNoteReply(message);
+
+    assertEquals(
+        List.of("- test 1", "  1. subtest 1", "  1. subtest 2", "- test 2"),
+        reply.comments().toList());
+  }
+
+  @Test
+  void nonPlainListAreConvertedToSublist() {
+    SlackReply message =
+        new SlackReply(
+            Messages.of("""
       Test:
       - test 1
       - test 2
       - test 3
-            """));
+      """));
     var reply = new ShowNoteReply(message);
 
     assertEquals(
@@ -122,46 +160,28 @@ class ShowNoteReplyTest {
                 """
       Test A:
       - test A1
-        - test A12
+        a. test A12
       - test A2
       - test A3
 
       Test B:
-      - test B1
-      - test B2
-      - test B3
-            """));
+      1. test B1
+      2. test B2
+      3. test B3
+      """));
     var reply = new ShowNoteReply(message);
 
     assertEquals(
         List.of(
             "- Test A:",
             "  - test A1",
-            "    - test A12",
+            "    1. test A12",
             "  - test A2",
             "  - test A3",
             "- Test B:",
-            "  - test B1",
-            "  - test B2",
-            "  - test B3"),
-        reply.comments().toList());
-  }
-
-  @Test
-  void plainListWithSublistIsConvertedAsIs() {
-    SlackReply message =
-        new SlackReply(
-            Messages.of(
-                """
-      - test 1
-        - subtest 1
-        - subtest 2
-      - test 2
-            """));
-    var reply = new ShowNoteReply(message);
-
-    assertEquals(
-        List.of("- test 1", "  - subtest 1", "  - subtest 2", "- test 2"),
+            "  1. test B1",
+            "  2. test B2",
+            "  3. test B3"),
         reply.comments().toList());
   }
 


### PR DESCRIPTION
Ordered list and sublist transformation from Slack syntax to GitHub flavored markdown syntax were not supported: it was wrongly converted to simple lists.

It works only for ordered lists and sublists (not subsublists or more).