### PR TITLE
Adapt to the new conferences àll-events.json format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Adapt to the new conferences `àll-events.json` format (#139).
+
 ### Deprecated
 
 ### Removed

--- a/src/test/java/com/lescastcodeurs/bot/conferences/ConferenceTest.java
+++ b/src/test/java/com/lescastcodeurs/bot/conferences/ConferenceTest.java
@@ -2,7 +2,6 @@ package com.lescastcodeurs.bot.conferences;
 
 import static com.lescastcodeurs.bot.conferences.Conference.MAX_TIMESTAMP;
 import static com.lescastcodeurs.bot.conferences.Conference.MIN_TIMESTAMP;
-import static java.time.LocalTime.MIDNIGHT;
 import static java.time.ZoneOffset.UTC;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,9 +23,9 @@ class ConferenceTest {
   private static final String MISC = "CFP ends on 2023-01-01";
 
   private static final LocalDate START = LocalDate.of(2023, 4, 12);
-  private static final long START_STAMP = START.toEpochSecond(MIDNIGHT, UTC);
+  private static final long START_STAMP = START.atStartOfDay().toInstant(UTC).toEpochMilli();
   private static final LocalDate END = LocalDate.of(2023, 4, 14);
-  private static final long END_STAMP = END.toEpochSecond(MIDNIGHT, UTC);
+  private static final long END_STAMP = END.atStartOfDay().toInstant(UTC).toEpochMilli();
   private static final long[] DATES = new long[] {START_STAMP, END_STAMP};
 
   @Test
@@ -53,7 +52,6 @@ class ConferenceTest {
   private static Stream<Arguments> invalidDates() {
     return Stream.of(
         of((Object) new long[] {}),
-        of((Object) new long[] {MIN_TIMESTAMP}),
         of((Object) new long[] {MIN_TIMESTAMP, MAX_TIMESTAMP, MAX_TIMESTAMP}),
         // Disabled: https://github.com/scraly/developers-conferences-agenda/issues/319
         of((Object) new long[] {MAX_TIMESTAMP, MIN_TIMESTAMP}),

--- a/src/test/java/com/lescastcodeurs/bot/conferences/ConferencesTest.java
+++ b/src/test/java/com/lescastcodeurs/bot/conferences/ConferencesTest.java
@@ -37,8 +37,8 @@ class ConferencesTest {
         {
           "name": "Devoxx France",
           "date": [
-            2147483647,
-            2147483647
+            9223372036854775007,
+            9223372036854775007
           ],
           "hyperlink": "https://devoxx.fr/",
           "location": "France (Paris)",
@@ -47,8 +47,8 @@ class ConferencesTest {
         {
           "name": "Monitorama",
           "date": [
-            2147483647,
-            2147483647
+            9223372036854775007,
+            9223372036854775007
           ],
           "hyperlink": "http://monitorama.com/",
           "location": "USA",
@@ -57,8 +57,8 @@ class ConferencesTest {
         {
           "name": "Best Of Web",
           "date": [
-            -2147483648,
-            -2147483648
+            0,
+            0
           ],
           "hyperlink": "http://bestofweb.paris/",
           "location": "France",


### PR DESCRIPTION
- Declare new fields in conferences JSON parsing.
- Fix handling of conferences JSON dates:
  - the epoch timestamp is now expressed in milliseconds,
  - end date is now optional.

This closes #139.