### PR TITLE
Fix conferences retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix conferences retrieval (#161).
+
 ### Deprecated
 
 ### Removed
 
 ### Internal
-

--- a/src/main/java/com/lescastcodeurs/bot/conferences/Conference.java
+++ b/src/main/java/com/lescastcodeurs/bot/conferences/Conference.java
@@ -14,7 +14,7 @@ import java.util.Locale;
 
 // Those fields are not used (but we still want this object to exactly reflect the expected JSON
 // structure).
-@JsonIgnoreProperties({"cfp", "status"})
+@JsonIgnoreProperties({"cfp", "status", "closedCaptions"})
 @SuppressWarnings("java:S6218") // don't care
 public record Conference(String name, String hyperlink, String location, long[] date, String misc)
     implements MarkdownSerializable {


### PR DESCRIPTION
A new field, closedCaptions, was added recently: https://github.com/scraly/developers-conferences-agenda/pull/675.