### PR TITLE
Configure Jackson to not fail on unknown properties

### DIFF
--- a/src/main/java/com/lescastcodeurs/bot/conferences/Conference.java
+++ b/src/main/java/com/lescastcodeurs/bot/conferences/Conference.java
@@ -2,7 +2,6 @@ package com.lescastcodeurs.bot.conferences;
 
 import static com.lescastcodeurs.bot.internal.StringUtils.isBlank;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.lescastcodeurs.bot.MarkdownSerializable;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -12,9 +11,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
 
-// Those fields are not used (but we still want this object to exactly reflect the expected JSON
-// structure).
-@JsonIgnoreProperties({"cfp", "status", "closedCaptions"})
 @SuppressWarnings("java:S6218") // don't care
 public record Conference(String name, String hyperlink, String location, long[] date, String misc)
     implements MarkdownSerializable {

--- a/src/main/java/com/lescastcodeurs/bot/conferences/Conferences.java
+++ b/src/main/java/com/lescastcodeurs/bot/conferences/Conferences.java
@@ -1,5 +1,6 @@
 package com.lescastcodeurs.bot.conferences;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -18,7 +19,8 @@ public record Conferences(String json, List<String> selectionCriteria)
 
   private static final Logger LOG = LoggerFactory.getLogger(Conferences.class);
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   public Conferences {
     requireNonNull(json);

--- a/src/test/java/com/lescastcodeurs/bot/conferences/ConferencesTest.java
+++ b/src/test/java/com/lescastcodeurs/bot/conferences/ConferencesTest.java
@@ -62,7 +62,8 @@ class ConferencesTest {
           ],
           "hyperlink": "http://bestofweb.paris/",
           "location": "France",
-          "misc": ""
+          "misc": "",
+          "city": "Paris"
         }
       ]
       """,


### PR DESCRIPTION
The decision to fail on unknown properties was not a good one: the JSON schema was updated multiple times lately, causing the bot to fail during the retrieval of show notes just before episode 301 then 302.

